### PR TITLE
Replace liche with lychee for link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
 
       - name: Install link checker
         run: |
-          curl -fsSL -o liche https://github.com/appscodelabs/liche/releases/download/v0.1.0/liche-linux-amd64
-          chmod +x liche
-          sudo mv liche /usr/local/bin/liche
+          curl -fsSL -o lychee.tar.gz https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzf lychee.tar.gz --strip-components=1
+          chmod +x lychee
+          sudo mv lychee /usr/local/bin/lychee
+          rm lychee.tar.gz
 
       - name: Install npm packages
         run: |

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ release: gen-prod
 
 .PHONY: check-links
 check-links:
-	lychee --base http://localhost:1313 --max-concurrency 10 --exclude '^http://localhost:9090$$' 'public/**/*.html'
+	lychee --base-url http://localhost:1313 --max-concurrency 10 --exclude '^http://localhost:9090$$' 'public/**/*.html'
 
 VERSION ?=
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ release: gen-prod
 
 .PHONY: check-links
 check-links:
-	liche -r public -d http://localhost:1313 -c 10 -p -l -x '^http://localhost:9090$$'
+	lychee --base http://localhost:1313 --max-concurrency 10 --exclude '^http://localhost:9090$$' 'public/**/*.html'
 
 VERSION ?=
 


### PR DESCRIPTION
Replace the archived `appscodelabs/liche` link checker (last released 2018) with `lycheeverse/lychee` v0.24.2.

- CI installer downloads the lychee release tarball instead of the liche binary.
- Link-check invocation rewritten to lychee flags (`--base`, `--max-concurrency`, `--exclude`) with an explicit file glob.