### PR TITLE
Support semver build-metadata tags like v2026.7.10+akp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,10 @@ name: Release
 on:
   push:
     tags:
+      # Matches version tags including semver build-metadata suffixes,
+      # e.g. v2026.7.10 and v2026.7.10+akp. The `*` spans the `+akp`
+      # suffix (it only stops at `/`), so no separate pattern is needed.
       - "*.*"
-      - "akp/*.*"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What

Replaces the old `akp/*.*` tag trigger with support for semver build-metadata suffixes, so tags like `v2026.7.10+akp` trigger the Release workflow.

## Why

The previous AKP format `akp/v2026.6.19` required its own `akp/*.*` glob because `*` in `*.*` does not cross the `/` separator. The new format `v2026.7.10+akp` has no slash, so the existing `*.*` glob already matches it (the `*` spans the `+akp` suffix — `+` is only special inside a pattern, not in the ref being matched).

## Behavior

For `v2026.7.10+akp`:
- Triggers the Release workflow (matched by `*.*`).
- Deploys to **prod** — it contains neither `-alpha.` nor `-beta.`, so it takes the Release path, the same target the old `akp/*` tags hit.
- Updates the Meilisearch index, like any prod release.

A comment on the trigger documents this so `akp/*.*` isn't re-added.