### PR TITLE
Scope release tracker token to the tracker repo owner

### DIFF
--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -19,14 +19,26 @@ jobs:
         with:
           submodules: true
 
+      - name: Determine release tracker repo
+        id: tracker
+        run: |
+          # The Release-tracker URL in the commit body is the repo the script
+          # comments on. For +akp (ProductLine: ACE) releases this is
+          # appscode-cloud/CHANGELOG; otherwise it defaults to the current owner.
+          url=$(git show -s --format=%b | grep -i '^Release-tracker:' | head -n1 | sed -E 's/^[Rr]elease-tracker:[[:space:]]*//' | tr -d '\r\t ')
+          owner=$(echo "$url" | sed -nE 's#.*github.com/([^/]+)/([^/]+)/.*#\1#p')
+          repo=$(echo "$url" | sed -nE 's#.*github.com/([^/]+)/([^/]+)/.*#\2#p')
+          echo "owner=${owner:-${{ github.repository_owner }}}" >> "$GITHUB_OUTPUT"
+          echo "repo=${repo:-CHANGELOG}" >> "$GITHUB_OUTPUT"
+
       - name: Generate LGTM App token
         id: lgtm-app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
           private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: CHANGELOG
+          owner: ${{ steps.tracker.outputs.owner }}
+          repositories: ${{ steps.tracker.outputs.repo }}
           permission-pull-requests: write
 
       - name: Update release tracker


### PR DESCRIPTION
## Problem

The `release-tracker` job fails with `Resource not accessible by integration (HTTP 403)` on `+akp` releases — see [run 29234443726](https://github.com/kubedb/website/actions/runs/29234443726/job/86765775795).

The app token was hardcoded to `owner: ${{ github.repository_owner }}` (kubedb) + `repositories: CHANGELOG`. But the `Release-tracker:` URL in the commit body — which is the repo the script actually comments on — differs by product line:

- `v2026.7.10+akp` (ProductLine: ACE) → `appscode-cloud/CHANGELOG` → token has no access → 403
- `v2026.7.10` (ProductLine: KubeDB) → `kubedb/CHANGELOG` → works

## Fix

Add a step that derives the token owner/repo from the `Release-tracker:` URL in the merge commit body, so the token is always scoped to the repo the script writes to. Falls back to `github.repository_owner` / `CHANGELOG` when no URL is present, preserving existing behavior for default releases.

> [!NOTE]
> Requires the LGTM GitHub App to be installed on the `appscode-cloud` org with pull-requests write on its `CHANGELOG` repo.