### PR TITLE
layout: swagger passthrough for interactive API reference

### DIFF
--- a/layouts/swagger/single.html
+++ b/layouts/swagger/single.html
@@ -1,0 +1,1 @@
+{{- with .Resources.GetMatch "api.html" -}}{{ .Content | safeHTML }}{{- end -}}


### PR DESCRIPTION
## What

Adds `layouts/swagger/single.html`, a one-line raw-passthrough layout:

```go-html-template
{{- with .Resources.GetMatch "api.html" -}}{{ .Content | safeHTML }}{{- end -}}
```

Pages with `type: swagger` emit their bundled `api.html` resource **verbatim**. Because the template has no `{{ define "main" }}` block, Hugo skips `baseof.html`, so no header/footer/sidebar wraps the standalone Swagger UI.

## Why

The KubeDB Platform docs ship a self-contained, per-version Swagger UI page (`api.html`, spec inlined) generated from the platform OpenAPI spec. A `.html` file dropped into `content/` gets rendered as a wrapped page at the wrong URL; as a plain resource Hugo won't publish it. This layout is the mechanism that serves it byte-for-byte at `/docs/platform/<version>/api/reference/`.

Follows the existing `layouts/<type>/single.html` override pattern (e.g. `layouts/products/single.html`) — no theme change.

## Companion

Requires the docs repo change that ships `api.html` into the versioned tree: appscode-cloud/docs#144. **Land this first** so the layout exists when docs first aggregate.

## Verification

Built the full site with the real `hugo-product-theme` (Hugo 0.128.2): the page renders at `docs/platform/v2026.7.10/api/reference/index.html`, byte-identical (`cmp`) to source `api.html`, no theme chrome.